### PR TITLE
Add EditorConfig and ESLint to enforce the team's coding standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 8,
+    "sourceType": "module"
+  },
+  "rules": {
+    "curly": ["error", "multi-or-nest", "consistent"],
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "max-len": ["warn"],
+    "no-console": ["error", {
+      "allow": ["warn", "error"]
+    }],
+    "prefer-arrow-callback": ["warn"],
+    "quotes": ["warn", "single", {
+      "avoidEscape": true,
+      "allowTemplateLiterals": true
+    }],
+    "semi": ["error", "always"]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,9 +16,6 @@
     "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
     "max-len": ["warn"],
-    "no-console": ["error", {
-      "allow": ["warn", "error"]
-    }],
     "prefer-arrow-callback": ["warn"],
     "quotes": ["warn", "single", {
       "avoidEscape": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,15 +12,34 @@
     "sourceType": "module"
   },
   "rules": {
+    "array-bracket-spacing": ["error"],
+    "arrow-spacing": ["error"],
+    "block-spacing": ["error"],
+    "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
+    "camelcase": ["error"],
+    "comma-spacing": ["error"],
     "curly": ["error", "multi-or-nest", "consistent"],
+    "eqeqeq": ["error", "smart"],
     "indent": ["error", 2],
+    "key-spacing": ["error"],
+    "keyword-spacing": ["error"],
     "linebreak-style": ["error", "unix"],
-    "max-len": ["warn"],
+    "max-len": ["warn", {"code": 80}],
+    "newline-per-chained-call": ["warn", {"ignoreChainWithDepth": 2}],
+    "no-trailing-spaces": ["error"],
+    "no-var": ["error"],
+    "object-curly-spacing": ["error"],
+    "one-var-declaration-per-line": ["error", "always"],
     "prefer-arrow-callback": ["warn"],
-    "quotes": ["warn", "single", {
-      "avoidEscape": true,
-      "allowTemplateLiterals": true
-    }],
-    "semi": ["error", "always"]
+    "prefer-const": ["error"],
+    "quote-props": ["error", "as-needed"],
+    "quotes": ["warn", "double", {"avoidEscape": true, "allowTemplateLiterals": true}],
+    "semi": ["error", "always"],
+    "semi-spacing": ["error"],
+    "space-before-blocks": ["error", "always"],
+    "space-in-parens": ["error"],
+    "space-infix-ops": ["error"],
+    "space-unary-ops": ["error"],
+    "spaced-comment": ["error", "always", {"exceptions": ["/", "=", "-", "+"]}]
   }
 }


### PR DESCRIPTION
- `.editorconfig` overrides your editor's configurations to match the team's coding standards. For VSCode, you can install the EditorConfig extension [here](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig).
- `.eslintrc.json`helps detect any code on supported editors that might go against the team's coding standards. For VSCode, you can install the ESLint extension [here](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).

For ESLint in VSCode, if there's a problem with your code, you can see a list of errors and warnings on the status bar at the bottom of your window. Here's what to do:

- With **errors**, you'd better fix it.
- With **warnings**, use your best judgment. Sometimes, a line that is over 80 characters long is more readable than a wrapped line. Sometimes, chaining method calls on the same line is more compact and readable than putting each of them on a new line.