### PR TITLE
Fix ESLint not recognize browser's globals

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "env": {
+    "browser": true,
     "es6": true,
     "node": true
   },


### PR DESCRIPTION
Fix an issue where ESLint does not recognize browser JavaScript's global functions and objects, such as `alert()`, `document`, `window`, `XMLHttpRequest`.