### PR TITLE
Require 1 additional indentation in switch-case

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "comma-spacing": ["error"],
     "curly": ["error", "multi-or-nest", "consistent"],
     "eqeqeq": ["error", "smart"],
-    "indent": ["error", 2],
+    "indent": ["error", 2, {"SwitchCase": 1}],
     "key-spacing": ["error"],
     "keyword-spacing": ["error"],
     "linebreak-style": ["error", "unix"],


### PR DESCRIPTION
ESLint now requires `switch` statements to have its cases indented 1 level in.