### PR TITLE
Require curly braces on everything

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
     "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "camelcase": ["error"],
     "comma-spacing": ["error"],
-    "curly": ["error", "multi-or-nest", "consistent"],
+    "curly": ["error", "all"],
     "eqeqeq": ["error", "smart"],
     "indent": ["error", 2, {"SwitchCase": 1}],
     "key-spacing": ["error"],


### PR DESCRIPTION
:x: Examples of **incorrect** code with this option:

```js
if (foo) foo++;

while (bar)
    baz();

if (foo) {
    baz();
} else qux();
```

:heavy_check_mark: Examples of **correct** code with this option:

```js
if (foo) {
    foo++;
}

while (bar) {
    baz();
}

if (foo) {
    baz();
} else {
    qux();
}
```