### PR TITLE
Improve ESLint config and React code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,10 @@
     "es6": true,
     "node": true
   },
-  "extends": "eslint:recommended",
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,6 @@
     "key-spacing": ["error"],
     "keyword-spacing": ["error"],
     "linebreak-style": ["error", "unix"],
-    "max-len": ["warn", {"code": 80}],
     "newline-per-chained-call": ["warn", {"ignoreChainWithDepth": 2}],
     "no-trailing-spaces": ["error"],
     "no-var": ["error"],

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,7 @@
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+      - '#approved-reviews-by>=1'
+    actions:
+      merge:
+        method: merge

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.0",
     "eslint": "^6.8.0",
+    "eslint-plugin-react": "^7.18.0",
     "html-webpack-plugin": "^3.2.0",
     "http-server": "^0.12.1",
     "webpack": "^4.41.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "mysql": "^2.17.1",
     "path": "^0.12.7",
+    "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "style-loader": "^1.1.3"

--- a/src/components/Course.js
+++ b/src/components/Course.js
@@ -1,8 +1,21 @@
 import React from "react";
+import PropTypes from "prop-types";
 import "../public/index.css";
 
 
 export default class Course extends React.Component {
+  static get propTypes() {
+    return {
+      key: PropTypes.any,
+      code: PropTypes.any,
+      title: PropTypes.any,
+      credits: PropTypes.any,
+      description: PropTypes.any,
+      prereqs: PropTypes.any,
+      addCourse: PropTypes.func
+    };
+  }
+
   constructor(props) {
     super(props);
 

--- a/src/components/CourseContainer.js
+++ b/src/components/CourseContainer.js
@@ -3,9 +3,15 @@ import Course from "./Course";
 import FilterBar from "./FilterBar";
 import courses from "./CourseList";
 import filters from "./FilterList";
+import PropTypes from "prop-types";
 import "../public/index.css";
-
 export default class CourseContainer extends React.Component {
+  static get propTypes() {
+    return {
+      updateCourses: PropTypes.func
+    };
+  }
+
   constructor(props) {
     super(props);
 
@@ -64,10 +70,6 @@ export default class CourseContainer extends React.Component {
       addCourses: newCourses
     });
     this.props.updateCourses(newCourses);
-  }
-
-  componentWillMount() {
-    this.loadCourses();
   }
 
   render() {

--- a/src/components/EditPlan.js
+++ b/src/components/EditPlan.js
@@ -1,8 +1,15 @@
 import React from "react";
 import PlanCourse from "./PlanCourse";
+import PropTypes from "prop-types";
 import "../public/index.css";
 
 export default class EditPlan extends React.Component {
+  static get propTypes() {
+    return {
+      remove: PropTypes.func,
+      courses: PropTypes.any
+    };
+  }
 
   constructor(props) {
     super(props);
@@ -21,7 +28,7 @@ export default class EditPlan extends React.Component {
             </tr>
           </thead>
           <tbody>
-            {this.props.courses.map(c => <PlanCourse code={c.code} title={c.title}
+            {this.props.courses.map(c => <PlanCourse key={c.code} code={c.code} title={c.title}
               credits={c.credits} remove={this.props.remove}/>)}
           </tbody>
         </table>

--- a/src/components/FilterBar.js
+++ b/src/components/FilterBar.js
@@ -1,6 +1,15 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 export default class FilterBar extends React.Component {
+  static get propTypes() {
+    return {
+      options: PropTypes.any,
+      value: PropTypes.any,
+      onValueChange: PropTypes.func
+    };
+  }
+
   constructor(props) {
     super(props);
 

--- a/src/components/PlanCourse.js
+++ b/src/components/PlanCourse.js
@@ -1,6 +1,15 @@
 import React from "react";
-
+import PropTypes from "prop-types";
 export default class PlanCourse extends React.Component {
+  static get propTypes() {
+    return {
+      code: PropTypes.any,
+      title: PropTypes.any,
+      credits: PropTypes.any,
+      remove: PropTypes.func
+    };
+  }
+
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
I originally opened this branch to remove the `max-len` rule from ESLint, but it seems `master` has some new stuff that are not in `merge`.

This branch was created from the latest version of `master`, so treat this PR as the update from `master` to `merge`. I recommend making PRs that target the `merge` branch only from now on.

CHANGELOG:

- Add a React plugin to ESLint
- Remove the `max-len` rule from ESLint
- Add Mergify config (I think the commits have diverged, despite both `master` and `merge` has the exact same file.)
- @clairecahill 's fix of PropTypes validation error by ESLint