### PR TITLE
Fix a role bug caused by out-of-date JWT payload setup

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -17,7 +17,7 @@ function Home(props) {
   `;
 
   useEffect(() => {
-    function checkLoggedIn () {
+    async function checkLoggedIn () {
 
       // check to see if the user is logged in
       const validToken = loggedIn();
@@ -25,7 +25,7 @@ function Home(props) {
       if (validToken) {
 
         // render a page based on the users role
-        const profile = getProfile();
+        const profile = await getProfile();
         if (!profile.role) {
           setPageState(1);
         } else {

--- a/client/src/components/StudentHome.js
+++ b/client/src/components/StudentHome.js
@@ -34,10 +34,10 @@ export default class StudentHome extends React.Component {
     this.setState({
       loading: true
     });
-    const profile = getProfile();
+    const profile = await getProfile();
     const token = getToken();
     const server = `${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}`;
-    const getUrl = `http://${server}/user/${profile.sub}/plans/` +
+    const getUrl = `http://${server}/user/${profile.userId}/plans/` +
       `?accessToken=${token}`;
 
     let obj = [];

--- a/client/src/components/navbar/Navbar.js
+++ b/client/src/components/navbar/Navbar.js
@@ -8,10 +8,24 @@ import {withRouter} from "react-router-dom";
 import Notifications from "./Notifications";
 import History from "./History";
 import {getProfile} from "../../utils/authService";
+import {useEffect, useState} from "react";
 
 function Navbar(props) {
 
-  const profile = getProfile();
+  // role and function to set role, default to 0 (Student)
+  const [role, setRole] = useState(0);
+
+  useEffect(() => {
+    async function checkRole() {
+      const profile = await getProfile();
+      if (!profile.role) {
+        setRole(0);
+      } else {
+        setRole(profile.role);
+      }
+    }
+    checkRole();
+  }, []);
 
   const style = css`
 
@@ -49,7 +63,7 @@ function Navbar(props) {
         <p className="osu-logo">Oregon State University</p>
       </Link>
       <div className="right-container">
-        {profile.role ? <History /> : null}
+        {role ? <History /> : null}
         <Notifications />
         <button className="logout" onClick={() => logoutUser()}>Log out</button>
       </div>

--- a/client/src/components/view_plan/ViewPlan.js
+++ b/client/src/components/view_plan/ViewPlan.js
@@ -101,8 +101,8 @@ function ViewPlan(props) {
       }
 
       // get active user information
-      const profile = getProfile();
-      url = `http://${server}/user/${profile.sub}/` +
+      const profile = await getProfile();
+      url = `http://${server}/user/${profile.userId}/` +
         `?accessToken=${token}`;
       const response = await fetch(url);
       if (response.ok) {

--- a/client/src/utils/authService.js
+++ b/client/src/utils/authService.js
@@ -35,7 +35,24 @@ export function logout() {
   localStorage.removeItem("id_token");
 }
 
-// get payload data from token
-export function getProfile() {
-  return jwtDecode(getToken());
+// get the user associated with the JWT payload, or return an empty object `{}`
+// if the user cannot be found or on error
+export async function getProfile() {
+  try {
+    const token = getToken();
+
+    // find the User associated with the payload subject
+    const server = `${process.env.REACT_APP_API_HOST}:${process.env.REACT_APP_API_PORT}`;
+    const getUrl = `http://${server}/user/idRole?accessToken=${token}`;
+
+    const results = await fetch(getUrl);
+    const user = await results.json();
+    if (results.ok && user) {
+      return user;
+    } else {
+      return {};
+    }
+  } catch (err) {
+    return {};
+  }
 }


### PR DESCRIPTION
Since the user's role has been removed from the JWT, the React server must fetch the authenticated user based on their ID every time to get the role.

There were still some portions of the React code that used `.role` or `.userRole` after getting the JWT, which invalidated the Advisor and Head Advisor roles because `.role` or `.userRole` is `undefined` and thus such elevated user got set back to the Student role instead of their designated role.

This bug is fixed in this PR. The new `getProfile()` function of the React code returns either an empty object `{}` or an object containing only the `userId` and the `role`, e.g. `{userId: 123456, role: 2}`.